### PR TITLE
Add Respawn to the NTRIP Node

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package greenzie_ntrip_client
 1.2.2 (2023-01-06)
 ------------------
 * Adds ability to publish raw RTCM into uint8 multiarray
-* Added repawn to the node
+* Added respawn to the node
 
 1.2.0 (2022-08-11)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog for package greenzie_ntrip_client
 1.2.2 (2023-01-06)
 ------------------
 * Adds ability to publish raw RTCM into uint8 multiarray
+* Added repawn to the node
 
 1.2.0 (2022-08-11)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package greenzie_ntrip_client
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-1.2.2 (2023-01-06)
+1.2.2 (2023-02-14)
 ------------------
 * Adds ability to publish raw RTCM into uint8 multiarray
 * Added respawn to the node

--- a/launch/ntrip_client.launch
+++ b/launch/ntrip_client.launch
@@ -24,7 +24,12 @@
   <!-- ****************************************************************** -->
   <!-- NTRIP Client Node -->
   <!-- ****************************************************************** -->
-  <node name="ntrip_client_node" pkg="greenzie_ntrip_client" type="ntrip_ros.py" output="screen" ns="ntrip_client">
+  <node name="ntrip_client_node"
+        pkg="greenzie_ntrip_client"
+        type="ntrip_ros.py"
+        output="screen"
+        respawn="true"
+        ns="ntrip_client">
 
     <!-- Required parameters used to connect to the NTRIP server -->
     <param name="host"       value="$(arg host)" />


### PR DESCRIPTION
So that the node may live on forever. We have had this node crash on us in luna development (Maybe after too many TCP connection fails?)

This is a quick PR to allow the node to recover from crashes.