### PR TITLE
Update NMEA Max Message Length Parameter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,10 +2,11 @@
 Changelog for package greenzie_ntrip_client
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-1.2.2 (2023-02-14)
+1.2.2 (2023-03-14)
 ------------------
 * Adds ability to publish raw RTCM into uint8 multiarray
 * Added respawn to the node
+* Changed Default NMEA Max Message Length
 
 1.2.0 (2022-08-11)
 ------------------

--- a/launch/ntrip_client.launch
+++ b/launch/ntrip_client.launch
@@ -60,7 +60,7 @@
     <param name="rtcm_frame_id" value="odom" />
 
     <!-- Optional parameters that will allow for longer or shorter NMEA messages. Standard max length for NMEA is 82 -->
-    <param name="nmea_max_length" value="82" />
+    <param name="nmea_max_length" value="83" />
     <param name="nmea_min_length" value="3" />
 
     <!-- Use this parameter to change the type of RTCM message published by the node. Defaults to "mavros_msgs", but we also support "rtcm_msgs" -->


### PR DESCRIPTION
This PR updates the nmea_max_length parameter from 82 to 83 as the FixPosition GGA NMEA messages are 83 bytes long which was causing errors when the max length was set to 82. 
These messages are necessary for the NTRIP client to work correctly with the Topcon Topnet Live RTK corrections service. 
Tested on my computer with a Fixposition. 