### PR TITLE
Updating CI to latest orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ parameters:
 workflows:
   version: 2
   pushbuild:
+    unless: << pipeline.parameters.manual-bobcat-deploy >>
     jobs:
       # Build jobs
       - greenzie/debian_build:
@@ -55,8 +56,7 @@ workflows:
             - amd_debian_build
   
   manualdeploy:
-    when:
-      or: [ << pipeline.parameters.manual-bobcat-deploy >>, << pipeline.parameters.manual-bobcat-deploy >> ]
+    when: << pipeline.parameters.manual-bobcat-deploy >>
     jobs:
       # Build jobs
       - greenzie/debian_build:
@@ -70,6 +70,7 @@ workflows:
           executor: greenzie/debianize_arm64
 
       - greenzie/deploy:
+          context: GREENZIE
           name: "manual_deploy_all_bobcat"
           server_hostname: bobcat
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  greenzie: greenzie/build_and_publish_debs@0.0.6
+  greenzie: greenzie/build_and_publish_debs@dev:renamed_targz
 
 parameters:
   manual-bobcat-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,7 @@ workflows:
 
       - greenzie/debian_deploy_experimental:
           name: "deploy_all_bobcat"
+          context: GREENZIE
           server_hostname: bobcat
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,9 @@ workflows:
           executor: greenzie/debianize_arm64
 
       # Deployment jobs
-      - greenzie/deploy:
+      - greenzie/debian_deploy_experimental:
           name: "deploy_amd64_greenzie"
+          context: GREENZIE
           filters:
             branches:
               only:
@@ -34,8 +35,9 @@ workflows:
           requires:
             - amd_debian_build
 
-      - greenzie/deploy:
+      - greenzie/debian_deploy_experimental:
           name: "deploy_arm64_greenzie"
+          context: GREENZIE
           architecture: arm64
           filters:
             branches:
@@ -44,7 +46,7 @@ workflows:
           requires:
             - arm64_debian_build
 
-      - greenzie/deploy:
+      - greenzie/debian_deploy_experimental:
           name: "deploy_all_bobcat"
           server_hostname: bobcat
           filters:
@@ -69,7 +71,7 @@ workflows:
           platform: arm64
           executor: greenzie/debianize_arm64
 
-      - greenzie/deploy:
+      - greenzie/debian_deploy_experimental:
           context: GREENZIE
           name: "manual_deploy_all_bobcat"
           server_hostname: bobcat

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  greenzie: greenzie/build_and_publish_debs@0.0.2
+  greenzie: greenzie/build_and_publish_debs@0.0.6
 
 parameters:
   manual-bobcat-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,55 +1,50 @@
 version: 2.1
 
+orbs:
+  greenzie: greenzie/build_and_publish_debs@0.0.2
+
 workflows:
   version: 2
   pushbuild:
     jobs:
-      - debian_build
-      - deploy:
+      # Build jobs
+      - greenzie/debian_build:
+          name: "amd_debian_build"
+          platform: amd64
+          executor: greenzie/debianize_amd64
+
+      - greenzie/debian_build:
+          name: "arm64_debian_build"
+          platform: arm64
+          executor: greenzie/debianize_arm64
+
+      # Deployment jobs
+      - greenzie/deploy:
+          name: "deploy_amd64_greenzie"
           filters:
             branches:
               only:
                 - noetic
           requires:
-            - debian_build
+            - amd_debian_build
 
-jobs:
-  debian_build:
-    docker:
-      - image: greenzie/debianize-experimental:focal-noetic
-        auth:
-          username: $DOCKERHUB_GREENZIE_USERNAME
-          password: $DOCKERHUB_GREENZIE_PASSWORD
-    resource_class: small
-    steps:
-      - checkout
-      - run:
-          name: "Generate Changelogs"
-          command: greenzie-release changelog -r "${ROS_DISTRO}"
-      - run:
-          name: "Package debs (debuild)"
-          command: GITHUB_WORKSPACE="$PWD" greenzie-debianize all
-      - store_artifacts:
-          path: /debians
-      - persist_to_workspace:
-          root: /debians
-          paths:
-            - '*'
+      - greenzie/deploy:
+          name: "deploy_arm64_greenzie"
+          architecture: arm64
+          filters:
+            branches:
+              only:
+                - noetic
+          requires:
+            - arm64_debian_build
 
-  deploy:
-    docker:
-      - image: greenzie/aptly:3.19.1-focal-noetic
-        auth:
-          username: $DOCKERHUB_GREENZIE_USERNAME
-          password: $DOCKERHUB_GREENZIE_PASSWORD
-    resource_class: small
-    steps:
-      - add_ssh_keys
-      - attach_workspace:
-          at: /debians
-      - run:
-          name: Deploy to aptly.greenzie.com
-          environment:
-            SERVER_HOSTNAME: aptly.greenzie.com
-          command: |
-            aptly repo deploy -r experimental -n "${CIRCLE_BUILD_NUM}" -p "/debians"
+      - greenzie/deploy:
+          name: "deploy_all_bobcat"
+          server_hostname: bobcat
+          filters:
+            branches:
+              only:
+                - noetic
+          requires:
+            - arm64_debian_build
+            - amd_debian_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  greenzie: greenzie/build_and_publish_debs@dev:renamed_targz
+  greenzie: greenzie/build_and_publish_debs@0.0.7
 
 parameters:
   manual-bobcat-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,11 @@ version: 2.1
 orbs:
   greenzie: greenzie/build_and_publish_debs@0.0.2
 
+parameters:
+  manual-bobcat-deploy:
+    type: boolean
+    default: false
+
 workflows:
   version: 2
   pushbuild:
@@ -45,6 +50,28 @@ workflows:
             branches:
               only:
                 - noetic
+          requires:
+            - arm64_debian_build
+            - amd_debian_build
+  
+  manualdeploy:
+    when:
+      or: [ << pipeline.parameters.manual-bobcat-deploy >>, << pipeline.parameters.manual-bobcat-deploy >> ]
+    jobs:
+      # Build jobs
+      - greenzie/debian_build:
+          name: "amd_debian_build"
+          platform: amd64
+          executor: greenzie/debianize_amd64
+
+      - greenzie/debian_build:
+          name: "arm64_debian_build"
+          platform: arm64
+          executor: greenzie/debianize_arm64
+
+      - greenzie/deploy:
+          name: "manual_deploy_all_bobcat"
+          server_hostname: bobcat
           requires:
             - arm64_debian_build
             - amd_debian_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ parameters:
   manual-bobcat-deploy:
     type: boolean
     default: false
+  filter-branch:
+    type: string
+    default: noetic
 
 workflows:
   version: 2
@@ -31,7 +34,7 @@ workflows:
           filters:
             branches:
               only:
-                - noetic
+                - << pipeline.parameters.filter-branch >>
           requires:
             - amd_debian_build
 
@@ -42,7 +45,7 @@ workflows:
           filters:
             branches:
               only:
-                - noetic
+                - << pipeline.parameters.filter-branch >>
           requires:
             - arm64_debian_build
 
@@ -52,7 +55,7 @@ workflows:
           filters:
             branches:
               only:
-                - noetic
+                - << pipeline.parameters.filter-branch >>
           requires:
             - arm64_debian_build
             - amd_debian_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,8 @@ parameters:
   manual-bobcat-deploy:
     type: boolean
     default: false
+  # Use this parameter to change the branch that the deployment jobs are triggered on
+  # It's useful for testing the deployment jobs on a different branch before merging
   filter-branch:
     type: string
     default: noetic


### PR DESCRIPTION
We use the orb to build and push Debian packages to experimental

It's now working:
https://app.circleci.com/pipelines/gh/Greenzie/ntrip_client/26/workflows/ff6dee43-11c6-4df5-aee2-3ec28e9f5207