### PR TITLE
Add Alerting for Connection Errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,11 +21,13 @@ workflows:
       # Build jobs
       - greenzie/debian_build:
           name: "amd_debian_build"
+          context: GREENZIE
           platform: amd64
           executor: greenzie/debianize_amd64
 
       - greenzie/debian_build:
           name: "arm64_debian_build"
+          context: GREENZIE
           platform: arm64
           executor: greenzie/debianize_arm64
 
@@ -62,7 +64,7 @@ workflows:
           requires:
             - arm64_debian_build
             - amd_debian_build
-  
+
   manualdeploy:
     when: << pipeline.parameters.manual-bobcat-deploy >>
     jobs:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package greenzie_ntrip_client
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+1.2.5 (2023-07-17)
+------------------
+* Added Error Code publishing on a ROS message
+
 1.2.4 (2023-07-17)
 ------------------
 * Fixed Bug with Building Python Debian

--- a/scripts/ntrip_ros.py
+++ b/scripts/ntrip_ros.py
@@ -6,7 +6,7 @@ import json
 import importlib
 
 import rospy
-from std_msgs.msg import Header, UInt8MultiArray, MultiArrayDimension
+from std_msgs.msg import Header, UInt8MultiArray, MultiArrayDimension, UInt8
 from nmea_msgs.msg import Sentence
 
 from ntrip_client.ntrip_client import NTRIPClient
@@ -90,6 +90,7 @@ class NTRIPRos:
     # Setup the RTCM publisher
     self._rtcm_timer = None
     self._rtcm_pub = rospy.Publisher('rtcm', self._rtcm_message_type, queue_size=10)
+    self._error_code_pub = rospy.Publisher('error_code', UInt8, queue_size=10)
 
     # Initialize the client
     self._client = NTRIPClient(
@@ -103,7 +104,8 @@ class NTRIPRos:
       logerr=rospy.logerr,
       logwarn=rospy.logwarn,
       loginfo=rospy.loginfo,
-      logdebug=rospy.logdebug
+      logdebug=rospy.logdebug,
+      error_code_passthrough_function=self.error_code_passthrough
     )
 
     # Get some SSL parameters for the NTRIP client
@@ -187,6 +189,11 @@ class NTRIPRos:
     msg_out.data = rtcm
     
     return msg_out
+  
+  def error_code_passthrough(self, error_code):
+    msg_out = UInt8()
+    msg_out.data = error_code
+    self._error_code_pub(msg_out)
 
 if __name__ == '__main__':
   ntrip_ros = NTRIPRos()

--- a/scripts/ntrip_ros.py
+++ b/scripts/ntrip_ros.py
@@ -90,7 +90,7 @@ class NTRIPRos:
     # Setup the RTCM publisher
     self._rtcm_timer = None
     self._rtcm_pub = rospy.Publisher('rtcm', self._rtcm_message_type, queue_size=10)
-    self._error_code_pub = rospy.Publisher('error_code', UInt8, queue_size=10)
+    self._error_flags_pub = rospy.Publisher('error_flags', UInt8, queue_size=10)
 
     # Initialize the client
     self._client = NTRIPClient(
@@ -105,7 +105,7 @@ class NTRIPRos:
       logwarn=rospy.logwarn,
       loginfo=rospy.loginfo,
       logdebug=rospy.logdebug,
-      error_code_passthrough_function=self.error_code_passthrough
+      error_flags_passthrough_function=self.error_flags_passthrough
     )
 
     # Get some SSL parameters for the NTRIP client
@@ -190,10 +190,10 @@ class NTRIPRos:
     
     return msg_out
   
-  def error_code_passthrough(self, error_code):
+  def error_flags_passthrough(self, error_flags):
     msg_out = UInt8()
-    msg_out.data = error_code
-    self._error_code_pub.publish(msg_out)
+    msg_out.data = error_flags
+    self._error_flags_pub.publish(msg_out)
 
 if __name__ == '__main__':
   ntrip_ros = NTRIPRos()

--- a/scripts/ntrip_ros.py
+++ b/scripts/ntrip_ros.py
@@ -193,7 +193,7 @@ class NTRIPRos:
   def error_code_passthrough(self, error_code):
     msg_out = UInt8()
     msg_out.data = error_code
-    self._error_code_pub(msg_out)
+    self._error_code_pub.publish(msg_out)
 
 if __name__ == '__main__':
   ntrip_ros = NTRIPRos()

--- a/src/ntrip_client/ntrip_client.py
+++ b/src/ntrip_client/ntrip_client.py
@@ -30,6 +30,11 @@ class NTRIPClient:
   DEFAULT_RECONNECT_ATEMPT_WAIT_SECONDS = 5
   DEFAULT_RTCM_TIMEOUT_SECONDS = 4
 
+  ERROR_CODE_NO_ERROR = 0
+  ERROR_CODE_INVALID_CREDENTIALS = 1
+  ERROR_CODE_INVALID_MOUNTPOINT = 2
+  ERROR_CODE_UKNONW_CONNECTION_ERROR = 3
+
   def __init__(self, host, port, mountpoint, ntrip_version, username, password, error_code_passthrough_function, output_format='stream', logerr=logging.error, logwarn=logging.warning, loginfo=logging.info, logdebug=logging.debug):
     # Bit of a strange pattern here, but save the log functions so we can be agnostic of ROS
     self._logerr = logerr
@@ -146,19 +151,19 @@ class NTRIPClient:
 
     # Some debugging hints about the kind of error we received
     known_error = False
-    error_code = 0
+    error_code = self.ERROR_CODE_NO_ERROR
     if any(sourcetable in response for sourcetable in _SOURCETABLE_RESPONSES):
       self._logwarn('Received sourcetable response from the server. This probably means the mountpoint specified is not valid')
       known_error = True
-      error_code = 2
+      error_code = self.ERROR_CODE_INVALID_MOUNTPOINT
     elif any(unauthorized in response for unauthorized in _UNAUTHORIZED_RESPONSES):
       self._logwarn('Received unauthorized response from the server. Check your username, password, and mountpoint to make sure they are correct.')
       known_error = True
-      error_code = 1
+      error_code = self.ERROR_CODE_INVALID_CREDENTIALS
     elif not self._connected and (self._ntrip_version == None or self._ntrip_version == ''):
       self._logwarn('Received unknown error from the server. Note that the NTRIP version was not specified in the launch file. This is not necesarilly the cause of this error, but it may be worth checking your NTRIP casters documentation to see if the NTRIP version needs to be specified.')
       known_error = True
-      error_code = 3
+      error_code = self.ERROR_CODE_UKNONW_CONNECTION_ERROR
 
     # Wish we could just return from the above checks, but some casters return both a success and an error in the response
     # If we received any known error, even if we received a success it should be considered a failure
@@ -166,8 +171,8 @@ class NTRIPClient:
       self._logerr('Invalid response received from http://{}:{}/{}'.format(
         self._host, self._port, self._mountpoint))
       self._logerr('Response: {}'.format(response))
-      if error_code == 0:
-        error_code = 3
+      if error_code == self.ERROR_CODE_NO_ERROR:
+        error_code = self.ERROR_CODE_UKNONW_CONNECTION_ERROR
       self._error_code_passthrough(error_code)
       return False
     else:

--- a/src/ntrip_client/ntrip_client.py
+++ b/src/ntrip_client/ntrip_client.py
@@ -30,12 +30,13 @@ class NTRIPClient:
   DEFAULT_RECONNECT_ATEMPT_WAIT_SECONDS = 5
   DEFAULT_RTCM_TIMEOUT_SECONDS = 4
 
-  def __init__(self, host, port, mountpoint, ntrip_version, username, password, output_format='stream', logerr=logging.error, logwarn=logging.warning, loginfo=logging.info, logdebug=logging.debug):
+  def __init__(self, host, port, mountpoint, ntrip_version, username, password, error_code_passthrough_function, output_format='stream', logerr=logging.error, logwarn=logging.warning, loginfo=logging.info, logdebug=logging.debug):
     # Bit of a strange pattern here, but save the log functions so we can be agnostic of ROS
     self._logerr = logerr
     self._logwarn = logwarn
     self._loginfo = loginfo
     self._logdebug = logdebug
+    self._error_code_passthrough = error_code_passthrough_function
 
     # Save the server info
     self._host = host
@@ -145,15 +146,19 @@ class NTRIPClient:
 
     # Some debugging hints about the kind of error we received
     known_error = False
+    error_code = 0
     if any(sourcetable in response for sourcetable in _SOURCETABLE_RESPONSES):
       self._logwarn('Received sourcetable response from the server. This probably means the mountpoint specified is not valid')
       known_error = True
+      error_code = 2
     elif any(unauthorized in response for unauthorized in _UNAUTHORIZED_RESPONSES):
       self._logwarn('Received unauthorized response from the server. Check your username, password, and mountpoint to make sure they are correct.')
       known_error = True
+      error_code = 1
     elif not self._connected and (self._ntrip_version == None or self._ntrip_version == ''):
       self._logwarn('Received unknown error from the server. Note that the NTRIP version was not specified in the launch file. This is not necesarilly the cause of this error, but it may be worth checking your NTRIP casters documentation to see if the NTRIP version needs to be specified.')
       known_error = True
+      error_code = 3
 
     # Wish we could just return from the above checks, but some casters return both a success and an error in the response
     # If we received any known error, even if we received a success it should be considered a failure
@@ -161,10 +166,14 @@ class NTRIPClient:
       self._logerr('Invalid response received from http://{}:{}/{}'.format(
         self._host, self._port, self._mountpoint))
       self._logerr('Response: {}'.format(response))
+      if error_code == 0:
+        error_code = 3
+      self._error_code_passthrough(error_code)
       return False
     else:
       self._loginfo(
         'Connected to http://{}:{}/{}'.format(self._host, self._port, self._mountpoint))
+      self._error_code_passthrough(0)
       return True
 
 

--- a/src/ntrip_client/ntrip_client.py
+++ b/src/ntrip_client/ntrip_client.py
@@ -33,7 +33,7 @@ class NTRIPClient:
   ERROR_CODE_NO_ERROR = 0
   ERROR_CODE_INVALID_CREDENTIALS = 1
   ERROR_CODE_INVALID_MOUNTPOINT = 2
-  ERROR_CODE_UKNONW_CONNECTION_ERROR = 3
+  ERROR_CODE_UKNONW_CONNECTION_ERROR = 4
 
   def __init__(self, host, port, mountpoint, ntrip_version, username, password, error_code_passthrough_function, output_format='stream', logerr=logging.error, logwarn=logging.warning, loginfo=logging.info, logdebug=logging.debug):
     # Bit of a strange pattern here, but save the log functions so we can be agnostic of ROS

--- a/src/ntrip_client/ntrip_client.py
+++ b/src/ntrip_client/ntrip_client.py
@@ -30,18 +30,18 @@ class NTRIPClient:
   DEFAULT_RECONNECT_ATEMPT_WAIT_SECONDS = 5
   DEFAULT_RTCM_TIMEOUT_SECONDS = 4
 
-  ERROR_CODE_NO_ERROR = 0
-  ERROR_CODE_INVALID_CREDENTIALS = 1
-  ERROR_CODE_INVALID_MOUNTPOINT = 2
-  ERROR_CODE_UKNONW_CONNECTION_ERROR = 4
+  ERROR_FLAG_NO_ERROR = 0
+  ERROR_FLAG_INVALID_CREDENTIALS = 1
+  ERROR_FLAG_INVALID_MOUNTPOINT = 2
+  ERROR_FLAG_UNKNOWN_CONNECTION_ERROR = 4
 
-  def __init__(self, host, port, mountpoint, ntrip_version, username, password, error_code_passthrough_function, output_format='stream', logerr=logging.error, logwarn=logging.warning, loginfo=logging.info, logdebug=logging.debug):
+  def __init__(self, host, port, mountpoint, ntrip_version, username, password, error_flags_passthrough_function, output_format='stream', logerr=logging.error, logwarn=logging.warning, loginfo=logging.info, logdebug=logging.debug):
     # Bit of a strange pattern here, but save the log functions so we can be agnostic of ROS
     self._logerr = logerr
     self._logwarn = logwarn
     self._loginfo = loginfo
     self._logdebug = logdebug
-    self._error_code_passthrough = error_code_passthrough_function
+    self._error_flags_passthrough = error_flags_passthrough_function
 
     # Save the server info
     self._host = host
@@ -151,19 +151,19 @@ class NTRIPClient:
 
     # Some debugging hints about the kind of error we received
     known_error = False
-    error_code = self.ERROR_CODE_NO_ERROR
+    error_flags = self.ERROR_FLAG_NO_ERROR
     if any(sourcetable in response for sourcetable in _SOURCETABLE_RESPONSES):
       self._logwarn('Received sourcetable response from the server. This probably means the mountpoint specified is not valid')
       known_error = True
-      error_code = self.ERROR_CODE_INVALID_MOUNTPOINT
+      error_flags = error_flags | self.ERROR_FLAG_INVALID_MOUNTPOINT
     elif any(unauthorized in response for unauthorized in _UNAUTHORIZED_RESPONSES):
       self._logwarn('Received unauthorized response from the server. Check your username, password, and mountpoint to make sure they are correct.')
       known_error = True
-      error_code = self.ERROR_CODE_INVALID_CREDENTIALS
+      error_flags = error_flags | self.ERROR_FLAG_INVALID_CREDENTIALS
     elif not self._connected and (self._ntrip_version == None or self._ntrip_version == ''):
       self._logwarn('Received unknown error from the server. Note that the NTRIP version was not specified in the launch file. This is not necesarilly the cause of this error, but it may be worth checking your NTRIP casters documentation to see if the NTRIP version needs to be specified.')
       known_error = True
-      error_code = self.ERROR_CODE_UKNONW_CONNECTION_ERROR
+      error_flags = error_flags | self.ERROR_FLAG_UNKNOWN_CONNECTION_ERROR
 
     # Wish we could just return from the above checks, but some casters return both a success and an error in the response
     # If we received any known error, even if we received a success it should be considered a failure
@@ -171,14 +171,14 @@ class NTRIPClient:
       self._logerr('Invalid response received from http://{}:{}/{}'.format(
         self._host, self._port, self._mountpoint))
       self._logerr('Response: {}'.format(response))
-      if error_code == self.ERROR_CODE_NO_ERROR:
-        error_code = self.ERROR_CODE_UKNONW_CONNECTION_ERROR
-      self._error_code_passthrough(error_code)
+      if error_flags == self.ERROR_FLAG_NO_ERROR:
+        error_flags = error_flags | self.ERROR_FLAG_UNKNOWN_CONNECTION_ERROR
+      self._error_flags_passthrough(error_flags)
       return False
     else:
       self._loginfo(
         'Connected to http://{}:{}/{}'.format(self._host, self._port, self._mountpoint))
-      self._error_code_passthrough(0)
+      self._error_flags_passthrough(self.ERROR_FLAG_NO_ERROR)
       return True
 
 


### PR DESCRIPTION
This PR adds a error code publisher that allows the ROS agnostic `ntrip_client.py` to publish a `UInt8` error code to a ROS message. This will allow for other packages to read the error code and publish alerts based on the error code. 
This will be expandable to other errors outside of connection errors.
