### PR TITLE
Bump greenzie/build_and_publish_debs orb to 0.1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,33 +19,37 @@ workflows:
     unless: << pipeline.parameters.manual-bobcat-deploy >>
     jobs:
       # Build jobs
-      - greenzie/debian_build:
+      - greenzie/debian_build_simple:
           name: "amd_debian_build"
           context: GREENZIE
           platform: amd64
           executor: greenzie/debianize_amd64
+          generate_changelog: true
 
-      - greenzie/debian_build:
+      - greenzie/debian_build_simple:
           name: "arm64_debian_build"
           context: GREENZIE
           platform: arm64
           executor: greenzie/debianize_arm64
+          generate_changelog: true
 
   manualdeploy:
     when: << pipeline.parameters.manual-bobcat-deploy >>
     jobs:
       # Build jobs
-      - greenzie/debian_build:
+      - greenzie/debian_build_simple:
           name: "amd_debian_build"
           context: GREENZIE
           platform: amd64
           executor: greenzie/debianize_amd64
+          generate_changelog: true
 
-      - greenzie/debian_build:
+      - greenzie/debian_build_simple:
           name: "arm64_debian_build"
           context: GREENZIE
           platform: arm64
           executor: greenzie/debianize_arm64
+          generate_changelog: true
 
       - greenzie/debian_deploy_experimental:
           name: "deploy_amd64_greenzie"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  greenzie: greenzie/build_and_publish_debs@0.0.7
+  greenzie: greenzie/build_and_publish_debs@0.1.1
 
 parameters:
   manual-bobcat-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,14 +31,25 @@ workflows:
           platform: arm64
           executor: greenzie/debianize_arm64
 
-      # Deployment jobs
+  manualdeploy:
+    when: << pipeline.parameters.manual-bobcat-deploy >>
+    jobs:
+      # Build jobs
+      - greenzie/debian_build:
+          name: "amd_debian_build"
+          context: GREENZIE
+          platform: amd64
+          executor: greenzie/debianize_amd64
+
+      - greenzie/debian_build:
+          name: "arm64_debian_build"
+          context: GREENZIE
+          platform: arm64
+          executor: greenzie/debianize_arm64
+
       - greenzie/debian_deploy_experimental:
           name: "deploy_amd64_greenzie"
           context: GREENZIE
-          filters:
-            branches:
-              only:
-                - << pipeline.parameters.filter-branch >>
           requires:
             - amd_debian_build
 
@@ -46,42 +57,12 @@ workflows:
           name: "deploy_arm64_greenzie"
           context: GREENZIE
           architecture: arm64
-          filters:
-            branches:
-              only:
-                - << pipeline.parameters.filter-branch >>
           requires:
             - arm64_debian_build
 
       - greenzie/debian_deploy_experimental:
           name: "deploy_all_bobcat"
           context: GREENZIE
-          server_hostname: bobcat
-          filters:
-            branches:
-              only:
-                - << pipeline.parameters.filter-branch >>
-          requires:
-            - arm64_debian_build
-            - amd_debian_build
-
-  manualdeploy:
-    when: << pipeline.parameters.manual-bobcat-deploy >>
-    jobs:
-      # Build jobs
-      - greenzie/debian_build:
-          name: "amd_debian_build"
-          platform: amd64
-          executor: greenzie/debianize_amd64
-
-      - greenzie/debian_build:
-          name: "arm64_debian_build"
-          platform: arm64
-          executor: greenzie/debianize_arm64
-
-      - greenzie/debian_deploy_experimental:
-          context: GREENZIE
-          name: "manual_deploy_all_bobcat"
           server_hostname: bobcat
           requires:
             - arm64_debian_build


### PR DESCRIPTION
Bumps the CircleCI orb `greenzie/build_and_publish_debs` from `0.0.7` to `0.1.1`. No API changes required.